### PR TITLE
Remove term 'hearing impaired'

### DIFF
--- a/src/views/page/content/sponsor.md
+++ b/src/views/page/content/sponsor.md
@@ -252,7 +252,7 @@ This is perfect if you're bring your team to the event and have an open job that
 
 <h2 id="captions"><i class="fas fa-closed-captioning"></i> Captioning</h2>
 
-We will be live captioning all 24 talks for the hearing impaired. Your logo will be included on the site we use to display the captioning as well as the videos that we produce and upload to YouTube. 
+We will be live captioning all 24 talks. Your logo will be included on the site we use to display the captioning as well as the videos that we produce and upload to YouTube. 
 
 <h2 id="scholarships"><i class="fas fa-hand-holding-heart"></i> Scholarships</h2>
 


### PR DESCRIPTION
This term is generally considered outdated. Also, captioning benefits many people who are not Deaf or hard of hearing.

Some references:

> Hearing-impaired – This term is no longer accepted by most in the community but was at one time preferred, largely because it was viewed as politically correct.

[National Association of the Deaf Community and Culture FAQ](https://www.nad.org/resources/american-sign-language/community-and-culture-frequently-asked-questions/)

> Hearing Impaired:    An obsolete term.  Instead use "Deaf and hard of hearing." 

> Hearing Impaired. This term is regarded as offensive by the vast majority of Deaf people.

> Politicians used to prefer the term "hearing impaired," but the Deaf community loves the word "Deaf."

[LifePrint glossary](https://www.lifeprint.com/asl101/pages-layout/glossary.htm)